### PR TITLE
processor: enable processor to access src_path

### DIFF
--- a/example/example_parser.py
+++ b/example/example_parser.py
@@ -16,15 +16,16 @@ import typer
 from livereload import Server
 
 from repo_parser import Processor, Resource, get_resources, scan
+from repo_parser.filesystem import File
 
 
-def _process_markdown(file_contents: str):
-    metadata, _ = frontmatter.parse(file_contents)
+def _process_markdown(file: File):
+    metadata, _ = frontmatter.parse(file.content or "")
 
     filetype = metadata.get("type", "file")
     metadata.pop("type", None)  # remove "type" from the metadata
 
-    return filetype, metadata, file_contents
+    return filetype, metadata, file
 
 
 def _augment_metadata(resource: Resource, extra_metadata: dict):

--- a/repo_parser/__init__.py
+++ b/repo_parser/__init__.py
@@ -2,7 +2,7 @@
 A library for extracting metadata out of a source repository.
 """
 
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 
 from .filesystem import scan
 from .processor import Processor

--- a/repo_parser/resource.py
+++ b/repo_parser/resource.py
@@ -179,7 +179,7 @@ def _get_resources(
     for file in dir.files:
         for processor in processors:
             if processor.pattern.search(file.name):
-                filetype, metadata, _ = processor.process(file.content or "")
+                filetype, metadata, _ = processor.process(file)
                 if filetype != "file":
                     if dir_resource is None:
                         dir_resource = Resource(
@@ -204,7 +204,7 @@ def _get_resources(
     for file in dir.files:
         for processor in processors:
             if processor.pattern.search(file.name):
-                _, metadata, _ = processor.process(file.content or "")
+                _, metadata, _ = processor.process(file)
                 # Collect file path for batch querying
                 if file_paths is not None:
                     file_paths.append(file.src_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,13 +11,13 @@ from repo_parser.filesystem import Dir, File, Processor
 
 @pytest.fixture
 def default_processors():
-    def _process_markdown(file_contents: str):
-        metadata, _ = frontmatter.parse(file_contents)
+    def _process_markdown(file: File):
+        metadata, _ = frontmatter.parse(file.content or "")
 
         filetype = metadata.get("type", "file")
         metadata.pop("type", None)  # remove "type" from the metadata
 
-        return filetype, metadata, file_contents
+        return filetype, metadata, file
 
     return [
         Processor(re.compile(r"\.md$"), _process_markdown, True),

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -15,7 +15,9 @@ def test_get_resources(simple_filesystem, default_processors):
     processors = [
         *default_processors,
         Processor(
-            re.compile(r"Makefile"), lambda content: ("file", {}, content), False
+            re.compile(r"Makefile"),
+            lambda file: ("file", {}, file),
+            False,
         ),
     ]
     dir, repo = simple_filesystem
@@ -47,7 +49,9 @@ def test_directory_last_modified_from_children(simple_filesystem, default_proces
     processors = [
         *default_processors,
         Processor(
-            re.compile(r"Makefile"), lambda content: ("file", {}, content), False
+            re.compile(r"Makefile"),
+            lambda file: ("file", {}, file),
+            False,
         ),
     ]
     dir, repo = simple_filesystem
@@ -67,7 +71,9 @@ def test_repo_last_modified_from_all_descendants(simple_filesystem, default_proc
     processors = [
         *default_processors,
         Processor(
-            re.compile(r"Makefile"), lambda content: ("file", {}, content), False
+            re.compile(r"Makefile"),
+            lambda file: ("file", {}, file),
+            False,
         ),
     ]
     dir, repo = simple_filesystem


### PR DESCRIPTION
# What Changed

1. pass the whole File to processor

The processor should know more then just the contents of the file so it can emit useful warnings or errors about which file it is processing.

This is a somewhat breaking change to maybe we should bump the version to v0.1.0