### PR TITLE
resource: allow disabling the last modified lookup

### DIFF
--- a/repo_parser/resource.py
+++ b/repo_parser/resource.py
@@ -252,7 +252,12 @@ def _get_resources(
     return [dir_resource]
 
 
-def get_resources(repo: git.Repo, dir: Dir, processors: list[Processor]) -> Resource:
+def get_resources(
+    repo: git.Repo,
+    dir: Dir,
+    processors: list[Processor],
+    disable_last_modified: bool = False,
+) -> Resource:
     """
     Gets a list of resources from a scanned filesystem.
 
@@ -263,10 +268,6 @@ def get_resources(repo: git.Repo, dir: Dir, processors: list[Processor]) -> Reso
     # Collect file paths as we create resources (single pass)
     file_paths: list[PurePath] = []
     children = _get_resources(dir, PurePath(), processors, repo, file_paths)
-
-    # Batch query all commit dates at once
-    scan_root = dir.path
-    last_modified_map = _get_last_modified_batch(repo, file_paths, scan_root)
 
     root_resource = Resource(
         name=dir.path.name,
@@ -279,7 +280,11 @@ def get_resources(repo: git.Repo, dir: Dir, processors: list[Processor]) -> Reso
         last_modified=datetime.now(),
     )
 
+    # Batch query all commit dates at once
     # Apply last_modified dates
-    _apply_last_modified_map(root_resource, last_modified_map)
+    if not disable_last_modified:
+        scan_root = dir.path
+        last_modified_map = _get_last_modified_batch(repo, file_paths, scan_root)
+        _apply_last_modified_map(root_resource, last_modified_map)
 
     return root_resource


### PR DESCRIPTION
# What

1. add param to disable last modified index

Our usage of repo-parser in voltus does not make use of these lookups. They
current cost of 9s of time, disabling these brings our usage of repo-parser down
from 11s (w/ git ls-files PR) down to under 2s to parse & generate what we need.

This means running repo-parser & doing the codegen we want is now essentially
free, or takes 10s if we load this last modified metadata but just ignore it.

```
[00:31:23] Building system registry                                                                                                                                              build.py:36
           Indexing with repo-parser                                                                                                                                          registry.py:41
           repo-parser.scan                                                                                                                                              repo_indexer.py:290
           repo-parser.scan completed in 0.586231 seconds                                                                                                                repo_indexer.py:297
           repo-parser.get_resources
           repo-parser.get_resources completed in 0.024739 seconds                                                                                                       repo_indexer.py:304
           Indexing finished in 0.633778 seconds                                                                                                                              registry.py:43
[00:31:24] Built system registry 0.930671 seconds
```

## Long term plans

Ideally I think I'm going to leftpad a python package that is dedicated to
performing the last modified lookup (repo wide with 1 git log call, our 55k file
repo takes sub 3s for this call) and managing a cache on disk. This would allow
repo-parser to utilize this cache for these lookups & the sphinx plugin could
use the same lib & cache.
