### PR TITLE
DOCS: Remove LLM disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,6 @@ You can see a demo of a documentation site generated from this repo at:
 
 https://repo-parser-demo.netlify.app/
 
-> [!NOTE]
-> repo-parser is partly created with LLMs (specifically, Claude Code and ChatGPT), with heavy human curation.
-
 ## Usage
 
 For documentation generation and metadata extraction, see the example in `example/example_parser.py`.


### PR DESCRIPTION
This removes the README note about (parts of) repo-parser being created with LLMs.

- In 2026, "uses LLMs" is no longer meaningful project-level context on its own.
- For now, it's better to omit it than replace it with a rushed policy statement.

May add a statement in the future on human accountability and trust, but let's just leave it for now. This project is still (mostly) an experiment.